### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 src
+
+# Babel
+.babelrc


### PR DESCRIPTION
Using removed Babel 5 option: base.stage: https://github.com/gaearon/disposables/issues/6